### PR TITLE
G4E-7307: "Save changes" button from Glue42 shutting down pop-up doesn't save the layout updates properly

### DIFF
--- a/io-connect-desktop-components/src/components/Dialogs.tsx
+++ b/io-connect-desktop-components/src/components/Dialogs.tsx
@@ -27,7 +27,7 @@ function DialogsWrapper() {
   const shouldShowLayoutModifiedDialog =
     isLayoutModified() &&
     (config.operation === "systemShutdown" ||
-      config.operation === "systemRestart");
+      config.operation === "systemRestart" || config.operation === "layoutRestore");
 
   if (shouldShowLayoutModifiedDialog) {
     return <LayoutModifiedDialog config={config} setResult={setResult} />;


### PR DESCRIPTION
- Adding layoutRestore operation